### PR TITLE
Feature: add industry data to order and other fields

### DIFF
--- a/src/main/java/com/mercadopago/client/order/OrderCreateRequest.java
+++ b/src/main/java/com/mercadopago/client/order/OrderCreateRequest.java
@@ -5,8 +5,9 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.Map;
 
-// API version: 1ff4822a-2dfd-4393-800e-a562edb3fe32
+// API version: acd67b14-97c4-4a4a-840d-0a018c09654f
 
 /** Order class. */
 @Builder
@@ -53,4 +54,7 @@ public class OrderCreateRequest extends MPResource {
 
     /** Expiration time of the order. */
     private String expirationTime;
+
+    /** Additional info for the order. */
+    private Map<String, Object> additionalInfo;
 }

--- a/src/main/java/com/mercadopago/client/order/OrderItemRequest.java
+++ b/src/main/java/com/mercadopago/client/order/OrderItemRequest.java
@@ -2,7 +2,7 @@ package com.mercadopago.client.order;
 
 import lombok.Getter;
 
-// API version: 1ff4822a-2dfd-4393-800e-a562edb3fe32
+// API version: acd67b14-97c4-4a4a-840d-0a018c09654f
 
 /** OrderItemRequest class. */
 @Getter
@@ -23,10 +23,18 @@ public class OrderItemRequest {
     /** Category ID of the item. */
     private String categoryId;
 
+    /** Type of the item. */
+    private String type;
+
     /** Description of the item. */
     private String description;
 
     /** Picture URL of the item. */
     private String pictureUrl;
 
+    /** Warranty of the item. */
+    private Boolean warranty;
+
+    /** Event date of the item. */
+    private String eventDate;
 }

--- a/src/main/java/com/mercadopago/client/order/OrderPayerAddress.java
+++ b/src/main/java/com/mercadopago/client/order/OrderPayerAddress.java
@@ -1,0 +1,29 @@
+package com.mercadopago.client.order;
+
+import lombok.Builder;
+import lombok.Getter;
+
+// API version: acd67b14-97c4-4a4a-840d-0a018c09654f
+
+/** OrderPayerAddress class. */
+@Getter
+@Builder
+public class OrderPayerAddress {
+    /** Street name. */
+    private String streetName;
+
+    /** Street number. */
+    private String streetNumber;
+
+    /** Zip code. */
+    private String zipCode;
+
+    /** Neighborhood. */
+    private String neighborhood;
+
+    /** City. */
+    private String city;
+
+    /** State. */
+    private String state;
+}

--- a/src/main/java/com/mercadopago/client/order/OrderPayerAddressRequest.java
+++ b/src/main/java/com/mercadopago/client/order/OrderPayerAddressRequest.java
@@ -5,10 +5,10 @@ import lombok.Getter;
 
 // API version: acd67b14-97c4-4a4a-840d-0a018c09654f
 
-/** OrderPayerAddress class. */
+/** OrderPayerAddressRequest class. */
 @Getter
 @Builder
-public class OrderPayerAddress {
+public class OrderPayerAddressRequest {
     /** Street name. */
     private String streetName;
 

--- a/src/main/java/com/mercadopago/client/order/OrderPayerRequest.java
+++ b/src/main/java/com/mercadopago/client/order/OrderPayerRequest.java
@@ -1,17 +1,19 @@
 package com.mercadopago.client.order;
 
-import com.mercadopago.resources.common.Address;
 import com.mercadopago.resources.common.Identification;
 import com.mercadopago.resources.common.Phone;
 import lombok.Builder;
 import lombok.Getter;
 
-// API version: 1ff4822a-2dfd-4393-800e-a562edb3fe32
+// API version: acd67b14-97c4-4a4a-840d-0a018c09654f
 
 /** OrderPayerRequest class. */
 @Getter
 @Builder
 public class OrderPayerRequest {
+    /** Payer's entity type. */
+    private String entityType;
+
     /** Payer's email. */
     private String email;
 
@@ -31,6 +33,6 @@ public class OrderPayerRequest {
     private Phone phone;
 
     /** Address information. */
-    private Address address;
+    private OrderPayerAddress address;
 
 }

--- a/src/main/java/com/mercadopago/client/order/OrderPayerRequest.java
+++ b/src/main/java/com/mercadopago/client/order/OrderPayerRequest.java
@@ -33,6 +33,6 @@ public class OrderPayerRequest {
     private Phone phone;
 
     /** Address information. */
-    private OrderPayerAddress address;
+    private OrderPayerAddressRequest address;
 
 }

--- a/src/main/java/com/mercadopago/example/apis/order/CreateOrderWithIndustryFields.java
+++ b/src/main/java/com/mercadopago/example/apis/order/CreateOrderWithIndustryFields.java
@@ -92,14 +92,25 @@ public class CreateOrderWithIndustryFields {
         additionalInfo.put("platform.authentication", "2FA");
 
         // Travel info
-        additionalInfo.put("travel.passengers", new Object[] {
-                Map.of("first_name", "John", "last_name", "Doe", "identification",
-                        Map.of("type", "CPF", "number", "12345678900")),
-        });
-        additionalInfo.put("travel.routes", new Object[] {
-                Map.of("departure", "GRU", "destination", "CWB", "departure_date_time", "2024-12-01T12:00:00Z",
-                        "arrival_date_time", "2024-12-01T14:00:00Z", "company", "LATAM"),
-        });
+        Map<String, String> identification = new HashMap<>();
+        identification.put("type", "CPF");
+        identification.put("number", "12345678900");
+
+        Map<String, Object> passenger = new HashMap<>();
+        passenger.put("first_name", "John");
+        passenger.put("last_name", "Doe");
+        passenger.put("identification", identification);
+
+        additionalInfo.put("travel.passengers", new Object[] { passenger });
+
+        Map<String, Object> route = new HashMap<>();
+        route.put("departure", "GRU");
+        route.put("destination", "CWB");
+        route.put("departure_date_time", "2024-12-01T12:00:00Z");
+        route.put("arrival_date_time", "2024-12-01T14:00:00Z");
+        route.put("company", "LATAM");
+
+        additionalInfo.put("travel.routes", new Object[] { route });
 
         OrderCreateRequest request = OrderCreateRequest.builder()
                 .type("online")

--- a/src/main/java/com/mercadopago/example/apis/order/CreateOrderWithIndustryFields.java
+++ b/src/main/java/com/mercadopago/example/apis/order/CreateOrderWithIndustryFields.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Mercado Pago Create Order transaction.
+ * Mercado Pago Create Order with industry fields.
  *
  * @see <a href=
  *      "https://mercadopago.com/developers/en/reference/orders/online-payments/create/post">Documentation</a>.

--- a/src/main/java/com/mercadopago/example/apis/order/CreateOrderWithIndustryFields.java
+++ b/src/main/java/com/mercadopago/example/apis/order/CreateOrderWithIndustryFields.java
@@ -1,0 +1,141 @@
+package com.mercadopago.example.apis.order;
+
+import com.mercadopago.MercadoPagoConfig;
+import com.mercadopago.client.order.*;
+import com.mercadopago.core.MPRequestOptions;
+import com.mercadopago.exceptions.MPApiException;
+import com.mercadopago.resources.order.Order;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Mercado Pago Create Order transaction.
+ *
+ * @see <a href=
+ *      "https://mercadopago.com/developers/en/reference/orders/online-payments/create/post">Documentation</a>.
+ */
+public class CreateOrderWithIndustryFields {
+    public static void main(String[] args) {
+        MercadoPagoConfig.setAccessToken("{{ACCESS_TOKEN}}");
+
+        System.out.println("Initializing OrderClient...");
+        OrderClient client = new OrderClient();
+
+        System.out.println("Creating OrderPaymentRequest...");
+        OrderPaymentRequest payment = OrderPaymentRequest.builder()
+                .amount("100.00")
+                .paymentMethod(OrderPaymentMethodRequest.builder()
+                        .id("master")
+                        .type("credit_card")
+                        .token("{{CARD_TOKEN}}")
+                        .installments(1)
+                        .statementDescriptor("statement")
+                        .build())
+                .build();
+
+        System.out.println("Adding payment details:");
+        System.out.println("Payment Amount: " + payment.getAmount());
+        System.out.println("Payment Method ID: " + payment.getPaymentMethod().getId());
+
+        List<OrderPaymentRequest> payments = new ArrayList<>();
+        payments.add(payment);
+
+        System.out.println("Creating OrderCreateRequest...");
+
+        // Build additionalInfo map
+        Map<String, Object> additionalInfo = new HashMap<>();
+
+        // Payer info
+        additionalInfo.put("payer.authentication_type", "MOBILE");
+        additionalInfo.put("payer.registration_date", "2022-01-01T00:00:00Z");
+        additionalInfo.put("payer.is_prime_user", true);
+        additionalInfo.put("payer.is_first_purchase_online", false);
+        additionalInfo.put("payer.last_purchase", "2024-12-01T12:00:00Z");
+
+        // Shipment info
+        additionalInfo.put("shipment.express", true);
+        additionalInfo.put("shipment.local_pickup", false);
+
+        // Platform shipment
+        additionalInfo.put("platform.shipment.delivery_promise", "delivery_promise");
+        additionalInfo.put("platform.shipment.drop_shipping", "drop_shipping");
+        additionalInfo.put("platform.shipment.safety", "safety");
+        additionalInfo.put("platform.shipment.tracking.code", "TRACK123");
+        additionalInfo.put("platform.shipment.tracking.status", "status");
+        additionalInfo.put("platform.shipment.withdrawn", false);
+
+        // Platform seller
+        additionalInfo.put("platform.seller.id", "123456");
+        additionalInfo.put("platform.seller.name", "Seller name");
+        additionalInfo.put("platform.seller.email", "seller@example.com");
+        additionalInfo.put("platform.seller.status", "active");
+        additionalInfo.put("platform.seller.referral_url", "https://example.com");
+        additionalInfo.put("platform.seller.registration_date", "2020-05-01T00:00:00Z");
+        additionalInfo.put("platform.seller.hired_plan", "Premium");
+        additionalInfo.put("platform.seller.business_type", "E-commerce");
+        additionalInfo.put("platform.seller.address.zip_code", "01310000");
+        additionalInfo.put("platform.seller.address.street_name", "Av. Paulista");
+        additionalInfo.put("platform.seller.address.street_number", "100");
+        additionalInfo.put("platform.seller.address.city", "São Paulo");
+        additionalInfo.put("platform.seller.address.state", "SP");
+        additionalInfo.put("platform.seller.address.complement", "101");
+        additionalInfo.put("platform.seller.address.country", "Brasil");
+        additionalInfo.put("platform.seller.identification.type", "CNPJ");
+        additionalInfo.put("platform.seller.identification.number", "12.345.678/0001-99");
+        additionalInfo.put("platform.seller.phone.area_code", "11");
+        additionalInfo.put("platform.seller.phone.number", "999999999");
+
+        // Platform authentication
+        additionalInfo.put("platform.authentication", "2FA");
+
+        // Travel info
+        additionalInfo.put("travel.passengers", new Object[] {
+                Map.of("first_name", "John", "last_name", "Doe", "identification",
+                        Map.of("type", "CPF", "number", "12345678900")),
+        });
+        additionalInfo.put("travel.routes", new Object[] {
+                Map.of("departure", "GRU", "destination", "CWB", "departure_date_time", "2024-12-01T12:00:00Z",
+                        "arrival_date_time", "2024-12-01T14:00:00Z", "company", "LATAM"),
+        });
+
+        OrderCreateRequest request = OrderCreateRequest.builder()
+                .type("online")
+                .processingMode("automatic")
+                .totalAmount("100.00")
+                .externalReference("ref_12345")
+                .payer(OrderPayerRequest.builder().email("{{PAYER_EMAIL}}").build())
+                .transactions(OrderTransactionRequest.builder()
+                        .payments(payments)
+                        .build())
+                .additionalInfo(additionalInfo)
+                .build();
+
+        System.out.println("Total amount: " + request.getTotalAmount());
+        System.out.println("External reference: " + request.getExternalReference());
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("X-Idempotency-Key", "{{IDEMPOTENCY_KEY}}");
+
+        MPRequestOptions requestOptions = MPRequestOptions.builder()
+                .customHeaders(headers)
+                .build();
+
+        try {
+            System.out.println("Attempting to create order...");
+            Order order = client.create(request, requestOptions);
+            System.out.println("Order created: " + order.getId());
+            System.out.println("Order status: " + order.getStatus());
+        } catch (MPApiException mpApiException) {
+            System.out.println("Error creating order: " + mpApiException.getMessage());
+            System.out.println("Status Code: " + mpApiException.getStatusCode());
+            System.out.println("Error Code: " + mpApiException.getApiResponse());
+            System.out.println("Error Details: " + mpApiException.getCause());
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.out.println("Error creating order: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/mercadopago/resources/order/Order.java
+++ b/src/main/java/com/mercadopago/resources/order/Order.java
@@ -4,6 +4,7 @@ import com.mercadopago.net.MPResource;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.Map;
 
 /* API version: 1ff4822a-2dfd-4393-800e-a562edb3fe32 */
 
@@ -26,10 +27,16 @@ public class Order extends MPResource {
     /** Total Paid amount of the order. */
     private String totalPaidAmount;
 
-    /** Identifier of the site (country) to which the Mercado Pago application that created the Order belongs. */
+    /**
+     * Identifier of the site (country) to which the Mercado Pago application that
+     * created the Order belongs.
+     */
     private String countryCode;
 
-    /** Identifier of the user to which the Mercado Pago application that created the Order belongs. It is the person that will receive the payment. */
+    /**
+     * Identifier of the user to which the Mercado Pago application that created the
+     * Order belongs. It is the person that will receive the payment.
+     */
     private String userId;
 
     /** Status of Order. */
@@ -47,7 +54,10 @@ public class Order extends MPResource {
     /** Last modified date. */
     private String lastUpdatedDate;
 
-    /** Additional information that can be used to integrate with other systems, such as the identifier of the Order in the integrator's system. */
+    /**
+     * Additional information that can be used to integrate with other systems, such
+     * as the identifier of the Order in the integrator's system.
+     */
     private OrderIntegrationData integrationData;
 
     /** Configures which processing modes to use. */
@@ -71,7 +81,10 @@ public class Order extends MPResource {
     /** Date of expiration. */
     private String expirationTime;
 
-    /** Unique token that identifies your integration. You can get it in Your credentials. */
+    /**
+     * Unique token that identifies your integration. You can get it in Your
+     * credentials.
+     */
     private String clientToken;
 
     /** Items information. */
@@ -82,4 +95,7 @@ public class Order extends MPResource {
 
     /** Payer information. */
     private OrderPayer payer;
+
+    /** Additional info for the order. */
+    private Map<String, Object> additionalInfo;
 }

--- a/src/main/java/com/mercadopago/resources/order/Order.java
+++ b/src/main/java/com/mercadopago/resources/order/Order.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import java.util.List;
 import java.util.Map;
 
-/* API version: 1ff4822a-2dfd-4393-800e-a562edb3fe32 */
+/* API version: acd67b14-97c4-4a4a-840d-0a018c09654f */
 
 /** Order class. */
 @Getter

--- a/src/main/java/com/mercadopago/resources/order/OrderItem.java
+++ b/src/main/java/com/mercadopago/resources/order/OrderItem.java
@@ -2,7 +2,7 @@ package com.mercadopago.resources.order;
 
 import lombok.Getter;
 
-// API version: d0494f1c-8d81-4c76-ae1d-0c65bb8ef6de
+// API version: acd67b14-97c4-4a4a-840d-0a018c09654f
 
 /** OrderItem class. */
 @Getter
@@ -23,6 +23,9 @@ public class OrderItem {
     /** Category ID of the item. */
     private String categoryId;
 
+    /** Type of the item. */
+    private String type;
+
     /** Description of the item. */
     private String description;
 
@@ -32,4 +35,9 @@ public class OrderItem {
     /** External Code of the item. */
     private String externalCode;
 
+    /** Warranty of the item. */
+    private Boolean warranty;
+
+    /** Event date of the item. */
+    private String eventDate;
 }

--- a/src/test/java/com/mercadopago/resources/mocks/request/preference/preference_base.json
+++ b/src/test/java/com/mercadopago/resources/mocks/request/preference/preference_base.json
@@ -21,7 +21,8 @@
       "category_id": "games",
       "quantity": 2,
       "unit_price": 4000,
-      "currency_id": "BRL"
+      "currency_id": "BRL",
+      "warranty": false
     }
   ],
   "marketplace": "marketplace",
@@ -32,6 +33,8 @@
     "name": "Test",
     "surname": "User",
     "email": "test_user_64585784@testuser.com",
+    "is_prime_user": false,
+    "is_first_purchase_online": false,
     "phone": {
       "area_code": "11",
       "number": "4444-4444"


### PR DESCRIPTION
## Description
- Add industry data to Order
- Create example of Order creation with industry fields
- Create `OrderPayerAddressRequest`
- Add `entityType` to `PayerRequest`
- Add `type`, `eventDate` and `warranty` to `OrderItemRequest` and `OrderItem`